### PR TITLE
upgrade slim_lint version from 0.16 to 0.17

### DIFF
--- a/lib/pronto/slim_lint/version.rb
+++ b/lib/pronto/slim_lint/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module SlimLintVersion
-    VERSION = '0.9.5'.freeze
+    VERSION = '0.10.0'.freeze
   end
 end

--- a/lib/pronto/slim_lint/version.rb
+++ b/lib/pronto/slim_lint/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module SlimLintVersion
-    VERSION = '0.9.4'.freeze
+    VERSION = '0.9.5'.freeze
   end
 end

--- a/lib/pronto/slim_lint/version.rb
+++ b/lib/pronto/slim_lint/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module SlimLintVersion
-    VERSION = '0.10.0'.freeze
+    VERSION = '0.9.5'.freeze
   end
 end

--- a/pronto-slim_lint.gemspec
+++ b/pronto-slim_lint.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency('pronto', '~> 0.9.0')
-  s.add_dependency('slim_lint', '~> 0.16.0')
+  s.add_dependency('slim_lint', '~> 0.17.0')
   s.add_development_dependency('rake', '~> 11.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rspec-its', '~> 1.2')


### PR DESCRIPTION
Upgrade to the last version of slim_lint. The actual version of slim_lint is out of date and it create Rubocop errors, particularly with the `Layout/AlignArguments` !