### PR TITLE
Relax slim lint constraint

### DIFF
--- a/lib/pronto/slim_lint/version.rb
+++ b/lib/pronto/slim_lint/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module SlimLintVersion
-    VERSION = '0.9.5'.freeze
+    VERSION = '0.9.6'.freeze
   end
 end

--- a/pronto-slim_lint.gemspec
+++ b/pronto-slim_lint.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency('pronto', '~> 0.9.0')
-  s.add_dependency('slim_lint', '~> 0.17.0')
+  s.add_dependency('slim_lint', '~> 0.17', '>= 0.17')
   s.add_development_dependency('rake', '~> 11.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rspec-its', '~> 1.2')


### PR DESCRIPTION
Allows any pre-1.0 release of slim-lint newer than 0.17

pronto-rubocop does something similar:

```ruby
s.add_runtime_dependency('rubocop', '~> 0.60', '>= 0.49.1')
```